### PR TITLE
IT-352 - Beta APIs will no longer work in GKE 1.22

### DIFF
--- a/helm/tezos-api-gateway/templates/api/ingress.yaml
+++ b/helm/tezos-api-gateway/templates/api/ingress.yaml
@@ -3,9 +3,9 @@
 {{- $fullName := include "tezos-api-gateway.fullname" . -}}
 {{- $svcPort := .Values.api.service.port -}}
 {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 {{- else -}}
-apiVersion: extensions/v1beta1
+apiVersion: extensions/v1
 {{- end }}
 kind: Ingress
 metadata:
@@ -35,9 +35,12 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ .path }}
+            pathType: Prefix
             backend:
-              serviceName: {{ $fullName }}-api
-              servicePort: {{ $svcPort }}
+              service:
+                name: {{ $fullName }}-api
+                port:
+                  number: {{ $svcPort }}
           {{- end }}
     {{- end }}
   {{- end }}

--- a/helm/tezos-api-gateway/templates/generated-api/ingress.yaml
+++ b/helm/tezos-api-gateway/templates/generated-api/ingress.yaml
@@ -2,9 +2,9 @@
 {{- $fullName := include "tezos-api-gateway.fullname" . -}}
 {{- $svcPort := .Values.generatedApi.service.port -}}
 {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 {{- else -}}
-apiVersion: extensions/v1beta1
+apiVersion: extensions/v1
 {{- end }}
 kind: Ingress
 metadata:
@@ -34,9 +34,12 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ .path }}
+            pathType: Prefix
             backend:
-              serviceName: {{ $fullName }}-generated-api
-              servicePort: {{ $svcPort }}
+              service:
+                name: {{ $fullName }}-generated-api
+                port:
+                  number: {{ $svcPort }}
           {{- end }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
Beta APIs which will be removed in GKE 1.22:
```
/apis/admissionregistration.k8s.io/v1beta1/validatingwebhookconfigurations
/apis/extensions/v1beta1/ingresses
/apis/networking.k8s.io/v1beta1/ingressclasses
/apis/networking.k8s.io/v1beta1/ingresses
```